### PR TITLE
Test/splice multi binary package

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,6 @@ and then prepare to generate predictions:
 1. symbolator: will make predictions based on symbol sets
 2. libabigail: makes predictions based on corpora diffs (and an internal representation)
 
-And then the actual "does it work" is determined from running the original executable.
+And then the actual "does it work" is determined from running the original executable. The command
+can be written verbatim in the markdown, and for more complex commands you can write (and reference) a script
+under [tests](tests).

--- a/scripts/generate-matrix.py
+++ b/scripts/generate-matrix.py
@@ -7,7 +7,7 @@ import json
 
 # To start we are just going to test one OS and container
 containers = [
-    "ghcr.io/buildsi/spack-ubuntu-18.04",
+#    "ghcr.io/buildsi/spack-ubuntu-18.04",
     "ghcr.io/buildsi/spack-ubuntu-20.04",
 ]
 

--- a/splice.py
+++ b/splice.py
@@ -198,13 +198,15 @@ def run_libabigail(splices):
     """
     Run libabigail to add to the predictions
     """
-    abi = spack.spec.Spec("libabigail")
+    abi = spack.spec.Spec("libabigail target=x86_64_v4")
     abi.concretize()
     add_to_path(os.path.join(abi.prefix, "bin"))
     os.listdir(os.path.join(abi.prefix, "bin"))
     abicompat = spack.util.executable.which("abicompat")
     if not abicompat:
-        sys.exit("abicompat not found, make sure you do spack install libabigail+docs")
+        sys.exit(
+            "abicompat not found, make sure you do spack install libabigail target=x86_64_v4"
+        )
 
     for splice in splices:
         if not splice["libs"]:

--- a/splice.py
+++ b/splice.py
@@ -115,16 +115,24 @@ def prepare_splices(splices, spliced_lib, command):
         for key in ["libs", "corpora"]:
             if key not in splice:
                 splice[key] = []
-            if "predictions" not in splice:
-                splice["predictions"] = {}
+        if "predictions" not in splice:
+            splice["predictions"] = {}
 
         if "libs" not in splice:
             splice["libs"] = []
-        for dep in splice["spec"].dependencies():
+
+        deps = splice["spec"].dependencies()
+        seen = set([x.name for x in deps])
+        while deps:
+            dep = deps.pop(0)
+            new_deps = [x for x in dep.dependencies() if x.name not in seen]
+            [seen.add(x.name) for x in new_deps]
+            deps += new_deps
             if dep.name == spliced_lib:
                 splice["libs"].append(
                     {"dep": dep, "paths": list(add_contenders(dep, "lib"))}
                 )
+        print(splice["libs"])
 
     return splices
 

--- a/splice.py
+++ b/splice.py
@@ -175,10 +175,9 @@ def run_actual(splices, command):
     for splice in splices:
         if actual == None:
             cmd = "%s/bin/%s" % (splice["specA"].prefix, command)
-            print(cmd)
             res = run_command(cmd)
             if res["return_code"] != 0:
-                sys.exit("Warning, original command %s does not work." % cmd)
+                sys.exit("Original command %s does not work." % cmd)
 
         # Test the splice binary
         cmd = "%s/bin/%s" % (splice["spec"].prefix, command)

--- a/splices/openmpi_info.yaml
+++ b/splices/openmpi_info.yaml
@@ -1,0 +1,3 @@
+package: openmpi
+splice: zlib
+command: ompi_info

--- a/splices/python.yaml
+++ b/splices/python.yaml
@@ -1,3 +1,3 @@
 package: python
 splice: zlib
-command: python -c "import sys; print(sys.version_info)"
+command: python -c \"import sys; print(sys.version_info)\"

--- a/splices/python.yaml
+++ b/splices/python.yaml
@@ -1,0 +1,3 @@
+package: python
+splice: zlib
+command: python -c "import sys; print(sys.version_info)"

--- a/splices/python.yaml
+++ b/splices/python.yaml
@@ -1,3 +1,3 @@
 package: python
 splice: zlib
-command: python -c 'import sys; print(sys.version_info)'
+command: 'python -c "import sys; print(sys.version_info)"'

--- a/splices/python.yaml
+++ b/splices/python.yaml
@@ -1,3 +1,3 @@
 package: python
 splice: zlib
-command: python -c \"import sys; print(sys.version_info)\"
+command: python -c 'import sys; print(sys.version_info)'

--- a/splices/python.yaml
+++ b/splices/python.yaml
@@ -1,3 +1,3 @@
 package: python
 splice: zlib
-command: 'python -c "import sys; print(sys.version_info)"'
+command: python tests/python-version.py

--- a/splices/python3.yaml
+++ b/splices/python3.yaml
@@ -1,0 +1,3 @@
+package: python
+splice: zlib
+command: python3 tests/python-version.py

--- a/splices/xz.yaml
+++ b/splices/xz.yaml
@@ -1,0 +1,3 @@
+package: xz
+splice: zlib
+command: xz --version

--- a/splices/xz.yaml
+++ b/splices/xz.yaml
@@ -1,3 +1,0 @@
-package: xz
-splice: zlib
-command: xz --version

--- a/tests/python-version.py
+++ b/tests/python-version.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env/python
+
+import sys
+print(sys.version_info)

--- a/tests/python-version.py
+++ b/tests/python-version.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env/python
 
 import sys
+
 print(sys.version_info)


### PR DESCRIPTION
These updates make it possible to support splicing and matching specific libs. This currently stopped working in GitHub CI here because (for some reason) the libabigail build always has a different hash. It wasn't possible to rebuild with a target arch (failed) so the option I'm left with is to try running this on some cluster with SLURM. It also looks like we need to support the use case of having a splice from a different lib name (e.g., openmpi replaced with mpich) so I'll start on that this weekend.